### PR TITLE
Fix build test isues

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -26,8 +27,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pipx install hatch
         python -m pip install --upgrade pip
+        python -m pip install hatch
     - name: Install package
       run: |
         hatch env create dev

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,11 +26,14 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        pipx install hatch
         python -m pip install --upgrade pip
-        python -m pip install hatch
     - name: Install package
       run: |
         hatch env create dev
+    - name: Build package
+      run: |
+        hatch build
     - name: Test with pytest
       run: |
         hatch -e dev run pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "setuptools", "numpy>=2.0", "Cython>=3.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -32,9 +32,9 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-    "numpy>=2.0",
+    "numpy>=1.25",
     "scikit-learn>=1.4",
-    "scipy>=1.13",  # nnls issue, it will be fixed in 1.15
+    "scipy>=1.8,<1.12",  # nnls issue, it will be fixed in 1.15
     "matplotlib>=3.8",
     "jax",
     "optax",
@@ -55,9 +55,6 @@ dependencies = [
     "isort",
     "pylint",
     "jupyter",
-    "setuptools",
-    "numpy>=2.0",
-    "Cython>=3.0",
 ]
 
 [tool.hatch.build.hooks.cython]


### PR DESCRIPTION
This works on my local environment (py312, macos). Probably the issue is that older scipy does not support numpy 2.0. I listed numpy 2.0 as a build dependency (so that Cython compile against both numpy 1.x and 2.x), and numpy>=1.25 as project dependency.